### PR TITLE
Create API endpoints for operations on Coffee

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,9 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	implementation 'org.mapstruct:mapstruct:1.6.3'
+	annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/flight/thebrew/api/controller/CoffeeController.java
+++ b/src/main/java/com/flight/thebrew/api/controller/CoffeeController.java
@@ -1,10 +1,10 @@
 package com.flight.thebrew.api.controller;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import com.flight.thebrew.api.dto.CreateCoffeeDTO;
 import com.flight.thebrew.api.dto.GetCoffeeDTO;
 import com.flight.thebrew.core.service.CoffeeService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;

--- a/src/main/java/com/flight/thebrew/api/controller/CoffeeController.java
+++ b/src/main/java/com/flight/thebrew/api/controller/CoffeeController.java
@@ -1,0 +1,47 @@
+package com.flight.thebrew.api.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import com.flight.thebrew.api.dto.CreateCoffeeDTO;
+import com.flight.thebrew.api.dto.GetCoffeeDTO;
+import com.flight.thebrew.core.service.CoffeeService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/coffee")
+public class CoffeeController {
+
+    private final CoffeeService coffeeService;
+
+    @GetMapping("/{id}")
+    public GetCoffeeDTO getById(@PathVariable long id) {
+        log.info("Get by id= {}", id);
+        return coffeeService.getById(id);
+    }
+
+    @GetMapping
+    public List<GetCoffeeDTO> getByCost(@RequestParam int cost) {
+        log.info("Get by cost= {}", cost);
+        return coffeeService.getByCost(cost);
+    }
+
+    @PostMapping
+    public GetCoffeeDTO create(@RequestBody CreateCoffeeDTO createCoffeeDTO) {
+        return coffeeService.create(createCoffeeDTO);
+    }
+
+    @PutMapping("/{id} ")
+    public GetCoffeeDTO update(@PathVariable long id, @RequestBody CreateCoffeeDTO createCoffeeDTO) {
+        return coffeeService.update(id, createCoffeeDTO);
+    }
+
+    @DeleteMapping("/{id}")
+    public void delete(@PathVariable long id) {
+        coffeeService.delete(id);
+        log.info("Object with id= {} was successfully removed.", id);
+    }
+}

--- a/src/main/java/com/flight/thebrew/api/dto/CreateCoffeeDTO.java
+++ b/src/main/java/com/flight/thebrew/api/dto/CreateCoffeeDTO.java
@@ -1,0 +1,16 @@
+package com.flight.thebrew.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+@EqualsAndHashCode
+@AllArgsConstructor
+public class CreateCoffeeDTO {
+    private String name;
+    private Integer amount;
+    private Integer cost;
+}

--- a/src/main/java/com/flight/thebrew/api/dto/GetCoffeeDTO.java
+++ b/src/main/java/com/flight/thebrew/api/dto/GetCoffeeDTO.java
@@ -7,7 +7,7 @@ import lombok.Setter;
 
 @Setter
 @Getter
-@EqualsAndHashCode // чтобы их можно было сравнивать
+@EqualsAndHashCode
 @AllArgsConstructor
 public class GetCoffeeDTO {
     private Long id;

--- a/src/main/java/com/flight/thebrew/api/dto/GetCoffeeDTO.java
+++ b/src/main/java/com/flight/thebrew/api/dto/GetCoffeeDTO.java
@@ -1,0 +1,17 @@
+package com.flight.thebrew.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+@EqualsAndHashCode // чтобы их можно было сравнивать
+@AllArgsConstructor
+public class GetCoffeeDTO {
+    private Long id;
+    private String name;
+    private Integer amount;
+    private Integer cost;
+}

--- a/src/main/java/com/flight/thebrew/core/Coffee.java
+++ b/src/main/java/com/flight/thebrew/core/Coffee.java
@@ -1,0 +1,20 @@
+package com.flight.thebrew.core;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+@Builder
+@AllArgsConstructor
+public class Coffee {
+    private Long id;
+
+    private String name;
+
+    private Integer amount;
+
+    private Integer cost;
+}

--- a/src/main/java/com/flight/thebrew/core/service/CoffeeService.java
+++ b/src/main/java/com/flight/thebrew/core/service/CoffeeService.java
@@ -1,0 +1,18 @@
+package com.flight.thebrew.core.service;
+
+import com.flight.thebrew.api.dto.CreateCoffeeDTO;
+import com.flight.thebrew.api.dto.GetCoffeeDTO;
+import java.util.List;
+
+public interface CoffeeService {
+
+    GetCoffeeDTO getById(long id);
+
+    List<GetCoffeeDTO> getByCost(int cost);
+
+    GetCoffeeDTO create(CreateCoffeeDTO createCoffeeDTO);
+
+    GetCoffeeDTO update(long id, CreateCoffeeDTO createCoffeeDTO);
+
+    void delete(long id);
+}

--- a/src/main/java/com/flight/thebrew/core/service/CoffeeService.java
+++ b/src/main/java/com/flight/thebrew/core/service/CoffeeService.java
@@ -2,6 +2,7 @@ package com.flight.thebrew.core.service;
 
 import com.flight.thebrew.api.dto.CreateCoffeeDTO;
 import com.flight.thebrew.api.dto.GetCoffeeDTO;
+
 import java.util.List;
 
 public interface CoffeeService {

--- a/src/main/java/com/flight/thebrew/core/service/impl/CoffeeServiceImpl.java
+++ b/src/main/java/com/flight/thebrew/core/service/impl/CoffeeServiceImpl.java
@@ -1,0 +1,76 @@
+package com.flight.thebrew.core.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import com.flight.thebrew.api.dto.CreateCoffeeDTO;
+import com.flight.thebrew.api.dto.GetCoffeeDTO;
+import com.flight.thebrew.core.Coffee;
+import com.flight.thebrew.core.service.CoffeeService;
+import com.flight.thebrew.core.service.mapper.coffee.CreateCoffeeMapper;
+import com.flight.thebrew.core.service.mapper.coffee.GetCoffeeMapper;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CoffeeServiceImpl implements CoffeeService {
+
+    private final GetCoffeeMapper getCoffeeMapper;
+    private final CreateCoffeeMapper createCoffeeMapper;
+    private final List<Coffee> cacheRepository = new ArrayList<>(
+            List.of(
+                    Coffee.builder().id(1L).name("Arabica").amount(1).cost(10).build(),
+                    Coffee.builder().id(2L).name("Robusta").amount(1).cost(20).build()
+            )
+    );
+
+    @Override
+    public GetCoffeeDTO getById(long id) {
+        try {
+            return getCoffeeMapper.toDto(findById(id));
+        } catch (NoSuchElementException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        }
+    }
+
+    @Override
+    public List<GetCoffeeDTO> getByCost(int cost) {
+        return getCoffeeMapper.toDtos(
+                cacheRepository.stream()
+                        .filter((coffee) -> coffee.getCost().equals(cost))
+                        .collect(Collectors.toList())
+        );
+    }
+
+    @Override
+    public GetCoffeeDTO create(CreateCoffeeDTO createCoffeeDTO) {
+        cacheRepository.add(createCoffeeMapper.toEntity(createCoffeeDTO));
+        return getCoffeeMapper.toDto(createCoffeeMapper.toEntity(createCoffeeDTO));
+    }
+
+    @Override
+    public GetCoffeeDTO update(long id, CreateCoffeeDTO createCoffeeDTO) {
+        Coffee coffee = findById(id);
+        Coffee savedCoffee = createCoffeeMapper.merge(coffee, createCoffeeDTO);
+        return getCoffeeMapper.toDto(savedCoffee);
+    }
+
+    @Override
+    public void delete(long id) {
+       cacheRepository.remove(findById(id));
+    }
+
+    private Coffee findById(long id) {
+        return cacheRepository.stream()
+                .filter(coffee -> coffee.getId() == id)
+                .findFirst()
+                .orElseThrow(() -> new NoSuchElementException("Coffee with id " + id + " not found"));
+    }
+}

--- a/src/main/java/com/flight/thebrew/core/service/impl/CoffeeServiceImpl.java
+++ b/src/main/java/com/flight/thebrew/core/service/impl/CoffeeServiceImpl.java
@@ -1,13 +1,13 @@
 package com.flight.thebrew.core.service.impl;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import com.flight.thebrew.api.dto.CreateCoffeeDTO;
 import com.flight.thebrew.api.dto.GetCoffeeDTO;
 import com.flight.thebrew.core.Coffee;
 import com.flight.thebrew.core.service.CoffeeService;
 import com.flight.thebrew.core.service.mapper.coffee.CreateCoffeeMapper;
 import com.flight.thebrew.core.service.mapper.coffee.GetCoffeeMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;

--- a/src/main/java/com/flight/thebrew/core/service/mapper/BaseMapper.java
+++ b/src/main/java/com/flight/thebrew/core/service/mapper/BaseMapper.java
@@ -1,0 +1,30 @@
+package com.flight.thebrew.core.service.mapper;
+
+import org.mapstruct.Builder;
+import org.mapstruct.MapperConfig;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValueMappingStrategy;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+import org.mapstruct.ReportingPolicy;
+
+import java.util.List;
+
+@MapperConfig(
+        componentModel = "spring",
+        builder = @Builder(disableBuilder = true),
+        unmappedTargetPolicy = ReportingPolicy.IGNORE,
+        nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE,
+        nullValueIterableMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT
+)
+
+public interface BaseMapper<E, D> {
+    D toDto(E e);
+
+    E toEntity(D d);
+
+    List<D> toDtos(Iterable<E> list);
+
+    List<E> toEntities(Iterable<D> list);
+
+    E merge(@MappingTarget E entity, D dto);
+}

--- a/src/main/java/com/flight/thebrew/core/service/mapper/coffee/CreateCoffeeMapper.java
+++ b/src/main/java/com/flight/thebrew/core/service/mapper/coffee/CreateCoffeeMapper.java
@@ -1,0 +1,10 @@
+package com.flight.thebrew.core.service.mapper.coffee;
+
+import com.flight.thebrew.api.dto.CreateCoffeeDTO;
+import com.flight.thebrew.core.Coffee;
+import com.flight.thebrew.core.service.mapper.BaseMapper;
+import org.mapstruct.Mapper;
+
+@Mapper(config = BaseMapper.class)
+public interface CreateCoffeeMapper extends BaseMapper<Coffee, CreateCoffeeDTO> {
+}

--- a/src/main/java/com/flight/thebrew/core/service/mapper/coffee/GetCoffeeMapper.java
+++ b/src/main/java/com/flight/thebrew/core/service/mapper/coffee/GetCoffeeMapper.java
@@ -1,0 +1,10 @@
+package com.flight.thebrew.core.service.mapper.coffee;
+
+import com.flight.thebrew.api.dto.GetCoffeeDTO;
+import com.flight.thebrew.core.Coffee;
+import com.flight.thebrew.core.service.mapper.BaseMapper;
+import org.mapstruct.Mapper;
+
+@Mapper(config = BaseMapper.class)
+public interface GetCoffeeMapper extends BaseMapper<Coffee, GetCoffeeDTO>{
+}


### PR DESCRIPTION
This PR introduces a RESTful API for managing Coffee resources. It includes the implementation of standard CRUD + 1 operations:
- Create POST /coffee - creates a new coffee
- Read (GET /coffee/{id}) - retrieves a specific coffee by ID
- Read a list by cost (GET /coffee) - fetches coffee by Cost
- Update (PUT /coffee/{id}) – Updates an existing [Entity]
- Delete (DELETE /coffee/{id}) – Deletes an [Entity]

Verified API responses using Postman.
Additional Notes:
 - A stub implementation with an ArrayList was used instead of a database. It's not my thing/aproach, for the training only.