### PR TITLE
Add Docker containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM eclipse-temurin:17-jdk
+
+WORKDIR /app
+
+COPY build/libs/the-brew-0.0.1-SNAPSHOT.jar app.jar
+
+CMD ["java", "-jar", "app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -30,14 +30,17 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.postgresql:postgresql'
 	implementation 'org.flywaydb:flyway-database-postgresql'
-	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+	developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
+	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	implementation 'org.mapstruct:mapstruct:1.6.3'
 	annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
+
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
 tasks.named('test') {

--- a/compose.yml
+++ b/compose.yml
@@ -28,4 +28,4 @@ services:
       SPRING_DATASOURCE_USERNAME: postgres
       SPRING_DATASOURCE_PASSWORD: password
     ports:
-      - "8080:8080"
+      - "8085:8080"

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,31 @@
+services:
+  postgres:
+    image: 'postgres:15'
+    container_name: the_brew_postgres
+    restart: always
+    environment:
+      - POSTGRES_DB=office
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_USER=postgres
+    ports:
+      - '5432'
+    healthcheck:
+      test: [ "CMD", "pg_isready", "-U", "postgres" ]
+      interval: 10s
+      retries: 5
+      start_period: 10s
+
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: the_brew_app
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/office
+      SPRING_DATASOURCE_USERNAME: postgres
+      SPRING_DATASOURCE_PASSWORD: password
+    ports:
+      - "8080:8080"

--- a/compose.yml
+++ b/compose.yml
@@ -8,7 +8,7 @@ services:
       - POSTGRES_PASSWORD=password
       - POSTGRES_USER=postgres
     ports:
-      - '5432'
+      - '5432:5432'
     healthcheck:
       test: [ "CMD", "pg_isready", "-U", "postgres" ]
       interval: 10s

--- a/compose.yml
+++ b/compose.yml
@@ -4,7 +4,7 @@ services:
     container_name: the_brew_postgres
     restart: always
     environment:
-      - POSTGRES_DB=office
+      - POSTGRES_DB=thebrew
       - POSTGRES_PASSWORD=password
       - POSTGRES_USER=postgres
     ports:
@@ -24,7 +24,7 @@ services:
       postgres:
         condition: service_healthy
     environment:
-      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/office
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/thebrew
       SPRING_DATASOURCE_USERNAME: postgres
       SPRING_DATASOURCE_PASSWORD: password
     ports:

--- a/src/test/java/com/flight/thebrew/TheBrewApplicationTests.java
+++ b/src/test/java/com/flight/thebrew/TheBrewApplicationTests.java
@@ -1,8 +1,10 @@
 package com.flight.thebrew;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
+@Disabled
 @SpringBootTest
 class TheBrewApplicationTests {
 


### PR DESCRIPTION
This PR add run the app and database in docker container.
- [x] add dockerfile 
- [x] add docker compose to describe containers

**Note! The external port is 8085.**

## Commands
Build the app JAR file:
```
gradle clean build
```
or just
```
./gradlew clean build
```
Run the containers with fresh build:
```
docker compose up -d --build
```
Stopping and cleaning up containers
```
docker compose down
```

## Additional commands
Check application logs:
```
docker compose logs -f app
```
Stop and remove all volumes:
```
docker compose down -v
```
Access the database inside the running container:
```
docker exec -it <container_id> psql -U postgres -d thebrew
```

![image](https://github.com/user-attachments/assets/09229001-5528-411f-ab76-ca8bc0c5635d)